### PR TITLE
Switch BrowserRouter to HashRouter for direct navigation fix

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import './App.css';
 import React from "react";
 import {
-  BrowserRouter,
+  HashRouter,
   Routes,
   Route
 } from "react-router-dom";
@@ -18,7 +18,7 @@ function App() {
   
   return (
     <div class="page">
-      <BrowserRouter>
+      <HashRouter>
           <Sidebar pageWrapId={'page-wrap'} outerContainerId={'outer-container'} />
           <Header />
           <Routes>
@@ -28,7 +28,7 @@ function App() {
               <Route path="/projects" element={ <Projects />} />
           </Routes>
           <Footer />
-        </BrowserRouter>
+        </HashRouter>
     </div>
   );
 }


### PR DESCRIPTION
This pull request changes the routing method in the application from `BrowserRouter` to `HashRouter` in `App.js`. 

### Summary of changes:
- **Issue Addressed**: Direct navigation to paths like `/projects` resulted in a 404 error due to the hosting setup on S3 and CloudFront, which does not support client-side routing without proper rewrite rules.
- **Solution Implemented**: 
  - Switched from `BrowserRouter` to `HashRouter`, which allows the application to use hash-based routing. This means URLs will now include a `#` (e.g., `/#/projects`), preventing the server from trying to resolve these paths directly.
  - This change ensures that all requests are routed to the root (`/`), allowing React Router to handle the routing client-side without requiring server-side configuration changes.
- **Verification**: The build was successful, and local testing confirmed that direct navigation to any path now resolves correctly to the application.

This change simplifies the routing for the current hosting setup while maintaining functionality. If clean URLs are desired in the future, further configuration on the server side would be necessary.