### PR TITLE
Fix direct-navigation 404s and hero splash blocking page content

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import './App.css';
 import React from "react";
 import {
-  BrowserRouter,
+  HashRouter,
   Routes,
   Route
 } from "react-router-dom";
@@ -18,7 +18,7 @@ function App() {
   
   return (
     <div class="page">
-      <BrowserRouter>
+      <HashRouter>
           <Sidebar pageWrapId={'page-wrap'} outerContainerId={'outer-container'} />
           <Header />
           <Routes>
@@ -28,7 +28,7 @@ function App() {
               <Route path="/projects" element={ <Projects />} />
           </Routes>
           <Footer />
-        </BrowserRouter>
+        </HashRouter>
     </div>
   );
 }

--- a/src/Components/Header/index.js
+++ b/src/Components/Header/index.js
@@ -1,15 +1,26 @@
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
 import Splash from "../Header/Splash";
-// import { useLocation } from 'react-router-dom';
 import Navigation from './nav';
 
 function Header() {
-    // const location = useLocation();
-    // let showSplash = location.pathname === "/" && <Splash />;
+    const location = useLocation();
+    const stuckContainerRef = useRef(null);
+
+    useEffect(() => {
+        // Skip the hero splash and jump straight to the nav/content for any
+        // page other than Home, so the new content is visible without manual scrolling.
+        if (location.pathname === "/") {
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+        } else if (stuckContainerRef.current) {
+            stuckContainerRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+    }, [location.pathname]);
 
     return (
         <header id="header" class="header">
             <Splash />
-            <div id="stuck_container" class="stuck_container">
+            <div id="stuck_container" class="stuck_container" ref={stuckContainerRef}>
                 <div class="container">
                     <div class="row">
                         <div class="grid_12">


### PR DESCRIPTION
## Summary
Two related UX/routing fixes:

1. **Direct navigation 404s** — The app used `react-router-dom`'s `BrowserRouter`, which produces real-looking paths like `/projects`. The site is hosted on S3 + CloudFront with no fallback rewrite rule to `index.html`, so refreshing or directly navigating to a route (e.g. `https://www.vktrgama.io/projects`) returned a 404. Switched to `HashRouter` so all client-side routes live under `#/...` and the browser only ever requests `/` from the server — no infrastructure changes required.

2. **Page content hidden below the fold after navigating** — The `Header` component always renders a large (~550px) hero splash image above the nav bar and page content on every route. After clicking a nav item, the new page content rendered off-screen below the hero, requiring the user to scroll down manually. Added a `useEffect` in `Header` keyed on the route so that:
   - Navigating to **Home** scrolls to the top (hero remains visible, unchanged behavior).
   - Navigating to any **other** page (About, Projects, Dashboard) smooth-scrolls past the hero straight to the nav/content.

## Testing
- `npm run build` succeeds (pre-existing lint warnings only, unrelated to these changes).
- Verified locally by serving the production build and navigating between routes in a browser: Home shows the hero at top; About/Projects scroll straight to content without manual scrolling; direct hash-route navigation loads correctly instead of 404ing.
